### PR TITLE
Loosen libgdal pinned version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - libpng >=1.6.32,<1.6.35
     - jpeg 9*
     - libtiff >=4.0.8,<4.0.10
-    - libgdal 2.2.3.*
+    - libgdal 2.2.*
     - jsoncpp 1.8.3.*
     - expat 2.2.*
     - tbb
@@ -57,7 +57,7 @@ requirements:
     - libpng >=1.6.32,<1.6.35
     - jpeg 9*
     - libtiff >=4.0.8,<4.0.10
-    - libgdal 2.2.3.*
+    - libgdal 2.2.*
     - jsoncpp 1.8.3.*
     - expat 2.2.*
     - tbb


### PR DESCRIPTION
When new patch revisions of the libgdal packages are released on
conda-forge, the old versions are labelled as 'broken'. These 'broken'
packages aren't found when used as a dependency.

This commit loosens the pinned version of libgdal to allow patch
updates.